### PR TITLE
Added Swift Target.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,10 @@ let package = Package(
             name: "URLUtils",
             targets: ["URLUtils"]
         ),
+        .library(
+            name: "URLUtilsSwift",
+            targets: ["URLUtilsSwift"]
+        ),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -28,9 +32,13 @@ let package = Package(
             dependencies: [],
             publicHeadersPath: "include"
         ),
+        .target(
+            name: "URLUtilsSwift",
+            dependencies: [ "URLUtils" ]
+        ),
         .testTarget(
             name: "URLUtilsTests",
-            dependencies: ["URLUtils"]
+            dependencies: ["URLUtils", "URLUtilsSwift"]
         ),
     ]
 )

--- a/Sources/URLUtilsSwift/URLUtilsAdditions.swift
+++ b/Sources/URLUtilsSwift/URLUtilsAdditions.swift
@@ -1,0 +1,15 @@
+//
+//  URLUtilsAdditions.swift
+//
+//
+//  Created by Guillermo Ignacio Enriquez Gutierrez on 2023/06/14.
+//
+
+import Foundation
+import URLUtils
+
+extension URL {
+    public var queryParams: [String: String] {
+        (self as NSURL).queryParams
+    }
+}

--- a/Tests/URLUtilsTests/URLUtilsTests.swift
+++ b/Tests/URLUtilsTests/URLUtilsTests.swift
@@ -1,7 +1,7 @@
 import Foundation
 import XCTest
-//@testable import URLUtils
-import URLUtils
+
+import URLUtilsSwift
 
 class URLUtilsTestsSwift: XCTestCase {
 


### PR DESCRIPTION
Since NSURL and URL are *NOT* the same type, compiler does magic and makes the bridge. However for extensions defined like this compiler will not help.

The solution is to add an swift extension that calls the ObjC code. Conclusion: Two targets are needed. One for ObjC and other for Swift.

See explanation and solution in [Swift Forums - Why SPM library with Objective-C NSURL category is not available in Swift URL type?](https://forums.swift.org/t/why-spm-library-with-objective-c-nsurl-category-is-not-available-in-swift-url-type/65005)